### PR TITLE
Verify if "request" method is defined in conditional loop

### DIFF
--- a/lib/lazy_high_charts/layout_helper.rb
+++ b/lib/lazy_high_charts/layout_helper.rb
@@ -42,7 +42,7 @@ module LazyHighCharts
         })()
         </script>
         EOJS
-      elsif defined?(Turbolinks) && request.headers["X-XHR-Referer"]
+      elsif defined?(Turbolinks) && defined?(request) && request.headers["X-XHR-Referer"]
         graph =<<-EOJS
         <script type="text/javascript">
         (function() {


### PR DESCRIPTION
This commit solves issue #194.
The request method is verified on the if clause but not on the elsif part, breaking when calling the headers method on an object that doesn't exist.
This is an inprovement on the code robustness that doesn't seem to break anyone's code.
